### PR TITLE
chore: widen dart compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.1
 homepage: https://github.com/VeryGoodOpenSource/pub_updater
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   http: ^0.13.3


### PR DESCRIPTION
## Description

This package is fully compatible with 2.12 and should be declared that way.

The problem I'm currently running into:

```
The current Dart SDK version is 2.12.4.

Because mason >=0.0.1-dev.52 depends on pub_updater >=0.1.1 which requires SDK version >=2.13.0 <3.0.0, mason >=0.0.1-dev.52 is forbidden.
So, because sidekick depends on mason ^0.0.1-dev.57, version solving failed.
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
