### PR TITLE
feat: Allow PubUpdater to be instantiated with custom dart api base url

### DIFF
--- a/lib/src/pub_updater.dart
+++ b/lib/src/pub_updater.dart
@@ -19,17 +19,12 @@ const _defaultBaseUrl = 'https://pub.dev/api/packages/';
 /// {@endtemplate}
 class PubUpdater {
   /// {@macro pub_update}
-  PubUpdater([http.Client? client, String customBaseUrl = _defaultBaseUrl])
-      : assert(
-          _isValidBaseURL(customBaseUrl),
-          '$customBaseUrl is not a valid pub api URL!',
-        ),
-        _client = client,
-        _baseUrl = customBaseUrl;
+  PubUpdater([http.Client? client, String baseUrl = _defaultBaseUrl])
+      : _client = client,
+        _baseUrl = baseUrl;
 
-  /// The base url used for querying package versions
-  final String _baseUrl;
   final http.Client? _client;
+  final String _baseUrl;
 
   Future<http.Response> _get(Uri uri) => _client?.get(uri) ?? http.get(uri);
 
@@ -75,11 +70,5 @@ class PubUpdater {
     if (packageJson.isEmpty) throw PackageInfoNotFoundFailure();
 
     return PackageInfo.fromJson(packageJson);
-  }
-
-  /// Checks whether the passed [baseUrl] is a valid pub api url
-  static bool _isValidBaseURL(String baseUrl) {
-    return (Uri.tryParse(baseUrl)?.isAbsolute ?? false) &&
-        baseUrl.endsWith('/api/packages/');
   }
 }

--- a/lib/src/pub_updater.dart
+++ b/lib/src/pub_updater.dart
@@ -11,15 +11,24 @@ class PackageInfoRequestFailure implements Exception {}
 /// Exception thrown when the provided package information is not found.
 class PackageInfoNotFoundFailure implements Exception {}
 
+/// The pub.dev base url for querying package versions
+const _defaultBaseUrl = 'https://pub.dev/api/packages/';
+
 /// {@template pub_update}
 /// A Dart package which enables checking whether a package is up to date.
 /// {@endtemplate}
 class PubUpdater {
   /// {@macro pub_update}
-  PubUpdater([http.Client? client]) : _client = client;
+  PubUpdater([http.Client? client, String customBaseUrl = _defaultBaseUrl])
+      : assert(
+          _isValidBaseURL(customBaseUrl),
+          '$customBaseUrl is not a valid pub api URL!',
+        ),
+        _client = client,
+        _baseUrl = customBaseUrl;
 
-  /// The pub.dev base url for querying package versions
-  static const _baseUrl = 'https://pub.dev/api/packages/';
+  /// The base url used for querying package versions
+  final String _baseUrl;
   final http.Client? _client;
 
   Future<http.Response> _get(Uri uri) => _client?.get(uri) ?? http.get(uri);
@@ -66,5 +75,11 @@ class PubUpdater {
     if (packageJson.isEmpty) throw PackageInfoNotFoundFailure();
 
     return PackageInfo.fromJson(packageJson);
+  }
+
+  /// Checks whether the passed [baseUrl] is a valid pub api url
+  static bool _isValidBaseURL(String baseUrl) {
+    return (Uri.tryParse(baseUrl)?.isAbsolute ?? false) &&
+        baseUrl.endsWith('/api/packages/');
   }
 }

--- a/test/pub_update_test.dart
+++ b/test/pub_update_test.dart
@@ -80,6 +80,7 @@ void main() {
       test('makes correct http request with a custom base url', () async {
         when(() => response.body).thenReturn(emptyResponseBody);
         pubUpdater = PubUpdater(client, customBaseUrl);
+
         try {
           await pubUpdater.isUpToDate(
             packageName: 'very_good_cli',
@@ -159,6 +160,7 @@ void main() {
       test('makes correct http request with a custom base url', () async {
         when(() => response.body).thenReturn(emptyResponseBody);
         pubUpdater = PubUpdater(client, customBaseUrl);
+
         try {
           await pubUpdater.getLatestVersion('very_good_cli');
         } catch (_) {}

--- a/test/pub_update_test.dart
+++ b/test/pub_update_test.dart
@@ -52,7 +52,7 @@ void main() {
       expect(PubUpdater(), isNotNull);
     });
 
-    test('can be instantiated with correct custom base URL', () {
+    test('can be instantiated with a custom base url', () {
       expect(PubUpdater(null, customBaseUrl), isNotNull);
     });
 
@@ -77,7 +77,7 @@ void main() {
         ).called(1);
       });
 
-      test('makes correct http request with custom base url', () async {
+      test('makes correct http request with a custom base url', () async {
         when(() => response.body).thenReturn(emptyResponseBody);
         pubUpdater = PubUpdater(client, customBaseUrl);
         try {
@@ -156,7 +156,7 @@ void main() {
         ).called(1);
       });
 
-      test('makes correct http request with custom base url', () async {
+      test('makes correct http request with a custom base url', () async {
         when(() => response.body).thenReturn(emptyResponseBody);
         pubUpdater = PubUpdater(client, customBaseUrl);
         try {

--- a/test/pub_update_test.dart
+++ b/test/pub_update_test.dart
@@ -155,7 +155,7 @@ void main() {
     });
 
     group('getLatestVersion', () {
-      test('makes correct http request', () async {
+      test('makes correct http request (default)', () async {
         when(() => response.body).thenReturn(emptyResponseBody);
 
         try {
@@ -166,6 +166,23 @@ void main() {
           () => client.get(
             Uri.https(
               'pub.dev',
+              '/api/packages/very_good_cli',
+            ),
+          ),
+        ).called(1);
+      });
+
+      test('makes correct http request (custom domain)', () async {
+        when(() => response.body).thenReturn(emptyResponseBody);
+
+        try {
+          await pubUpdaterWithCustomBaseURL.getLatestVersion('very_good_cli');
+        } catch (_) {}
+
+        verify(
+          () => client.get(
+            Uri.https(
+              customDomain,
               '/api/packages/very_good_cli',
             ),
           ),

--- a/test/pub_update_test.dart
+++ b/test/pub_update_test.dart
@@ -61,7 +61,7 @@ void main() {
     test('cannot be instantiated with incorrect custom base URL', () {
       expect(
         () => PubUpdater(null, 'this-is-wrong.com'),
-        throwsA(TypeMatcher<AssertionError>()),
+        throwsA(isA<AssertionError>()),
       );
     });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Added an optional String attribute to the PubUpdater constructor, such that a custom pub api Url can be passed and will be used by the PubUpdater during all the different calls.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
